### PR TITLE
Add Makefile to init & distribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ config.py
 *.log
 .directory
 *.egg-info
+venv/
+*.marker

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ config.py
 .directory
 *.egg-info
 venv/
+build/
+dist/
 *.marker

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,14 @@ init.marker: setup.py
 	touch init.marker
 init: init.marker
 .PHONY: init
+
+#################################### W H E E L   T A R G E T S ####################################
+init-build.marker: init
+	pip install -e .[build]
+	touch init-build.marker
+
+init-build: init-build.marker
+.PHONY: init-build
+
+wheel: init-build
+	python -m build --wheel

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+################################
+#    Makefile for pyavtools    #
+################################
+SHELL := /bin/bash
+
+
+##################################### I N I T   T A R G E T S #####################################
+venv:
+	python3 -m venv venv
+.PHONY: venv
+
+init.marker: setup.py
+	pip install -e .[install]
+	touch init.marker
+init: init.marker
+.PHONY: init

--- a/README.rst
+++ b/README.rst
@@ -60,5 +60,16 @@ Then, you can install all required dependencies:
 Afterwards, you are ready to develop. Once one or more dependencies have changed, simply run
 `make init` again.
 
+Distribution
+------------
+
+To create a Python wheel for distribution, run:
+
+::
+
+  make wheel
+
+The wheel will be then created in the `dist/` directory.
+
 Requirements
 ------------

--- a/README.rst
+++ b/README.rst
@@ -42,5 +42,23 @@ can issue the command...
 from the root directory of the source repository.  **Caution** This feature is still
 in development and may not work consistently.
 
+Development
+-----------
+
+To set up your development environment, you can create a virtualenv:
+
+::
+
+  make venv
+
+Then, you can install all required dependencies:
+
+::
+
+  make init
+
+Afterwards, you are ready to develop. Once one or more dependencies have changed, simply run
+`make init` again.
+
 Requirements
 ------------

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setuptools.setup(
     url="https://github.com/makerplane/pyAvDb",
     packages=setuptools.find_packages(exclude=["tests.*", "tests"]),
     install_requires = ['pyyaml',],
+    extras_require = {
+        'build': ['build==0.10.0']
+    },
     #data_files = datafiles,
     entry_points = {
         'console_scripts': ['makecifpindex=pyavtools.utils.MakeCIFPIndex:main'],


### PR DESCRIPTION
The makefile contains targets to create a venv, install all dependencies, and create a wheel.