### PR TITLE
Prevent infinite loops exchanging two different values between pyavtools.fix and the gateway

### DIFF
--- a/pyavtools/fix/__init__.py
+++ b/pyavtools/fix/__init__.py
@@ -109,7 +109,7 @@ class DB_Item(QObject):
     # Outputs the value to the send queue and on to the fixgw server
     def output_value(self):
         if self.block_output:
-            # Do not send data we jsut received
+            # Do not send data we just received
             self.block_output = False
             return
         flags = "1" if self.annunciate else "0"

--- a/pyavtools/fix/__init__.py
+++ b/pyavtools/fix/__init__.py
@@ -108,6 +108,10 @@ class DB_Item(QObject):
 
     # Outputs the value to the send queue and on to the fixgw server
     def output_value(self):
+        if self.block_output:
+            # Do not send data we jsut received
+            self.block_output = False
+            return
         flags = "1" if self.annunciate else "0"
         flags += "0" # if self.old else "0"
         flags += "1" if self.bad else "0"
@@ -296,6 +300,7 @@ class Database(object):
         item.old = False
         item.bad = True
         item.fail = True
+        item.block_output = False
         item.description = desc
         item.min = min
         item.max = max

--- a/pyavtools/fix/client.py
+++ b/pyavtools/fix/client.py
@@ -96,6 +96,12 @@ class ClientThread(threading.Thread):
             #except:
             #    pass
             # if x[2] != '00000' or x[2] != '0000':
+            # If the value we just received is different than
+            # the value we have and this item is set to be output
+            # we block it
+            if (str(item.value) != x[1]) and item.output:
+                item.block_output = True
+
             item.value = x[1]
 
 


### PR DESCRIPTION
In pyavtools.fix, when the gateway sent a value, if that value was different than the current value it triggered an output back to the gateway. This can result in loops where two different values get sent back and forth between pyavtools.fix and the gateway. This commit resolves this problem