### PR TITLE
Migrate to PyQt6

### DIFF
--- a/pyavtools/fix/__init__.py
+++ b/pyavtools/fix/__init__.py
@@ -18,9 +18,9 @@
 # from FIX-Gateway.
 
 try:
-    from PyQt5.QtCore import *
+    from PyQt6.QtCore import *
 except:
-    from PyQt4.QtCore import *
+    from PyQt5.QtCore import *
 
 import logging
 import threading

--- a/pyavtools/scheduler.py
+++ b/pyavtools/scheduler.py
@@ -17,9 +17,9 @@
 # This is a really low brow scheduler.
 
 try:
-    from PyQt5.QtCore import *
+    from PyQt6.QtCore import *
 except:
-    from PyQt4.QtCore import *
+    from PyQt5.QtCore import *
 
 import logging
 

--- a/pyavtools/scheduler.py
+++ b/pyavtools/scheduler.py
@@ -64,7 +64,7 @@ class ScheduleThread(QThread):
         for each in self.timers:
             each.start()
 
-        self.exec_()
+        self.exec()
 
     def stop(self):
         for t in self.timers:

--- a/pyavui/__init__.py
+++ b/pyavui/__init__.py
@@ -14,12 +14,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 try:
+    from PyQt6.QtGui import *
+    from PyQt6.QtCore import *
+    from PyQt6.QtWidgets import *
+except:
     from PyQt5.QtGui import *
     from PyQt5.QtCore import *
-    from PyQt5.QtWidgets import *
-except:
-    from PyQt4.QtGui import *
-    from PyQt4.QtCore import *
 
 import logging
 


### PR DESCRIPTION
PyQt6 was released four years ago, I think it is time we migrate to it.